### PR TITLE
Relative latitude calculation

### DIFF
--- a/src/main/java/org/radarcns/phone/PhoneLocationManager.java
+++ b/src/main/java/org/radarcns/phone/PhoneLocationManager.java
@@ -261,7 +261,18 @@ class PhoneLocationManager extends AbstractDeviceManager<PhoneLocationService, B
             longitudeReference = longitude;
             preferences.edit().putString(LONGITUDE_REFERENCE, longitude.toString()).apply();
         }
-        return longitude.subtract(longitudeReference).doubleValue();
+
+        double relativeLongitude = longitude.subtract(longitudeReference).doubleValue();
+
+        // Wraparound if relative longitude outside range of valid values [-180,180]
+        // assumption: relative longitude in interval [-540,540]
+        if (relativeLongitude > 180d) {
+            return relativeLongitude - 360d;
+        } else if (relativeLongitude < -180d) {
+            return relativeLongitude + 360d;
+        }
+
+        return relativeLongitude;
     }
 
     private float getRelativeAltitude(double absoluteAltitude) {


### PR DESCRIPTION
This allows the distance travelled to be calculated more accurately from the relative coordinates. The relative latitude is now defined as the actual latitude +/- a random value smaller than 4 degrees. (the random value is a constant for a given person)

The resulting 'band' of latitude in which a person could be corresponds mildly with the UTM latitude zones that are used for converting lat/lon coordinates to flat coordinates.